### PR TITLE
enhancement: allow user to manually select folder

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,7 @@ fn main() -> io::Result<()> {
 					</security>
 				</trustInfo>
 				</assembly>
-			"#
+			"#,
 		)
 		.compile()?;
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use std::{
 	io::Cursor,
 	os::windows::process::CommandExt,
 	path::{Path, PathBuf},
-	process::Command,
+	process::Command
 };
 
 use anyhow::Context;
@@ -36,13 +36,13 @@ pub struct App {
 	already_installed_folders: Vec<PathBuf>,
 	selected_game_folder: Option<usize>,
 	check_paths: Vec<(PathBuf, Option<String>)>,
-	manually_selected_folder: bool,
+	manually_selected_folder: bool
 }
 
 #[derive(Deserialize)]
 struct SteamLibraryFolder {
 	path: String,
-	apps: HashMap<String, String>,
+	apps: HashMap<String, String>
 }
 
 #[derive(Deserialize)]
@@ -59,7 +59,7 @@ struct SteamUser {
 	#[serde(alias = "Timestamp")]
 	#[serde(alias = "timestamp")]
 	#[serde(default)]
-	timestamp: u64,
+	timestamp: u64
 }
 
 impl App {
@@ -86,7 +86,7 @@ impl App {
 			already_installed_folders: vec![],
 			selected_game_folder: None,
 			check_paths: vec![],
-			manually_selected_folder: false,
+			manually_selected_folder: false
 		}
 	}
 }
@@ -108,13 +108,13 @@ impl eframe::App for App {
 				ui.label(
 					"It seems a critical error has occurred. Try restarting the installation \
 					 process, or give Atampy26 the following error message on Hitman Forum (note \
-					 that this does not say Nexus Mods).",
+					 that this does not say Nexus Mods)."
 				);
 
 				ui.label(
 					RichText::from(error)
 						.color(Color32::from_rgb(200, 50, 50))
-						.size(7.0),
+						.size(7.0)
 				);
 			});
 		} else {
@@ -452,13 +452,12 @@ impl eframe::App for App {
 					if !self.valid_game_folders.is_empty() {
 						if self.valid_game_folders.len() == 1 {
 							ui.label(
-								RichText::from(
-									if self.manually_selected_folder {
-										"✅ Game folder manually selected"
-									} else {
-										"✅ Game folder found automatically"
-									}
-								).size(7.0)
+								RichText::from(if self.manually_selected_folder {
+									"✅ Game folder manually selected"
+								} else {
+									"✅ Game folder found automatically"
+								})
+								.size(7.0)
 							);
 						} else {
 							ComboBox::from_label(
@@ -522,10 +521,20 @@ impl eframe::App for App {
 
 						ui.add_space(5.0);
 
-						if ui.button(RichText::from("Alternatively, you can manually select your installation folder").size(5.0)).clicked() {
+						if ui
+							.button(
+								RichText::from(
+									"Alternatively, you can manually select your installation \
+									 folder"
+								)
+								.size(5.0)
+							)
+							.clicked()
+						{
 							if let Some(folder) = FileDialog::new()
 								.set_title(
-									"Select your game folder; it should contain a folder called Retail"
+									"Select your game folder; it should contain a folder called \
+									 Retail"
 								)
 								.pick_folder()
 							{

--- a/src/app.rs
+++ b/src/app.rs
@@ -400,7 +400,7 @@ impl eframe::App for App {
 							}
 						}
 
-						for (path, username) in self.check_paths.iter().cloned() {
+						for (path, username) in &self.check_paths {
 							// Game folder has Retail
 							let subfolder_retail = path.join("Retail").is_dir();
 
@@ -419,9 +419,10 @@ impl eframe::App for App {
 								&& ishitman3 && !self
 								.valid_game_folders
 								.iter()
-								.any(|(x, y)| *x == path && y.is_some())
+								.any(|(x, y)| x == path && y.is_some())
 							{
-								self.valid_game_folders.push((path.to_owned(), username));
+								self.valid_game_folders
+									.push((path.to_owned(), username.to_owned()));
 
 								self.valid_game_folders = self
 									.valid_game_folders
@@ -502,19 +503,10 @@ impl eframe::App for App {
 					} else {
 						ui.label(
 							RichText::from(
-								"It doesn't look like HITMAN 3 is installed anywhere. Make sure \
-								 you're trying to install the framework on a copy of HITMAN 3 \
-								 installed via Steam, Epic Games Launcher/Legendary or the Xbox \
-								 app."
-							)
-							.size(7.0)
-						);
-
-						ui.label(
-							RichText::from(
-								"Try restarting your computer, and if that doesn't fix it, \
-								 contact Atampy26 on Hitman Forum (note that this does not say \
-								 Nexus Mods)."
+								"We couldn't find HITMAN 3 anywhere. Make sure you're trying to \
+								 install the framework on a copy of HITMAN 3 installed via Steam, \
+								 Epic Games Launcher/Legendary or the Xbox app, then select your \
+								 folder manually below."
 							)
 							.size(7.0)
 						);
@@ -522,13 +514,7 @@ impl eframe::App for App {
 						ui.add_space(5.0);
 
 						if ui
-							.button(
-								RichText::from(
-									"Alternatively, you can manually select your installation \
-									 folder"
-								)
-								.size(5.0)
-							)
+							.button(RichText::from("Select your game folder").size(7.0))
 							.clicked()
 						{
 							if let Some(folder) = FileDialog::new()
@@ -540,7 +526,7 @@ impl eframe::App for App {
 							{
 								self.performed_automatic_check = false;
 								self.manually_selected_folder = true;
-								self.check_paths.push((folder.to_owned(), None));
+								self.check_paths = vec![(folder, None)];
 							}
 						}
 					}

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
 	let native_options = eframe::NativeOptions {
 		initial_window_size: Some(Vec2 {
 			x: 1200.0,
-			y: 700.0,
+			y: 700.0
 		}),
 		icon_data: Some(load_icon(include_bytes!("icon.png"))),
 		..Default::default()
@@ -29,7 +29,7 @@ fn main() {
 	eframe::run_native(
 		"Simple Mod Framework Installer",
 		native_options,
-		Box::new(|_| Box::new(simple_mod_framework_installer::App::new())),
+		Box::new(|_| Box::new(simple_mod_framework_installer::App::new()))
 	);
 }
 
@@ -44,6 +44,6 @@ fn load_icon(data: &[u8]) -> eframe::IconData {
 	eframe::IconData {
 		rgba: icon_rgba,
 		width: icon_width,
-		height: icon_height,
+		height: icon_height
 	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
 	let native_options = eframe::NativeOptions {
 		initial_window_size: Some(Vec2 {
 			x: 1200.0,
-			y: 700.0
+			y: 700.0,
 		}),
 		icon_data: Some(load_icon(include_bytes!("icon.png"))),
 		..Default::default()
@@ -29,7 +29,7 @@ fn main() {
 	eframe::run_native(
 		"Simple Mod Framework Installer",
 		native_options,
-		Box::new(|_| Box::new(simple_mod_framework_installer::App::new()))
+		Box::new(|_| Box::new(simple_mod_framework_installer::App::new())),
 	);
 }
 
@@ -44,6 +44,6 @@ fn load_icon(data: &[u8]) -> eframe::IconData {
 	eframe::IconData {
 		rgba: icon_rgba,
 		width: icon_width,
-		height: icon_height
+		height: icon_height,
 	}
 }


### PR DESCRIPTION
This PR should alleviate any edge cases when the installer cannot find a valid game copy.

If you wanted, you could add also something which verifies the HITMAN3.exe like SMF does to avoid people installing it on copies that otherwise wouldn't be valid.
(Could just be a JSON file of the hashes stored in either this repo or the main SMF repo).